### PR TITLE
renamed 'request.auth' to 'request.kauth' because '.auth' is already …

### DIFF
--- a/connect/index.js
+++ b/connect/index.js
@@ -179,12 +179,12 @@ Keycloak.prototype.protect = function(spec) {
  * for linking authentication information from Keycloak to 
  * application-maintained user information.
  *
- * The `request.auth.grant` object contains the relevant tokens
+ * The `request.kauth.grant` object contains the relevant tokens
  * which may be inspected.
  *
  * For instance, to obtain the unique subject ID:
  *
- *     request.auth.grant.id_token.sub => bf2056df-3803-4e49-b3ba-ff2b07d86995
+ *     request.kauth.grant.id_token.sub => bf2056df-3803-4e49-b3ba-ff2b07d86995
  *
  * @param {Object} request The HTTP request.
  */
@@ -234,7 +234,7 @@ Keycloak.prototype.getGrant = function(request, response) {
   }
 
   if ( rawData && ! rawData.error ) {
-    var grant = this.grantManager.createGrant( rawData );
+    var grant = this.grantManager.createGrant( JSON.stringify(rawData) );
     var self = this;
 
     return this.grantManager.ensureFreshness(grant)

--- a/connect/middleware/grant-attacher.js
+++ b/connect/middleware/grant-attacher.js
@@ -3,7 +3,7 @@ module.exports = function(keycloak) {
   return function(request, response, next) {
     keycloak.getGrant( request, response )
       .then( function(grant) {
-        request.auth.grant = grant;
+        request.kauth.grant = grant;
       })
       .then( next )
       .catch( function() {

--- a/connect/middleware/logout.js
+++ b/connect/middleware/logout.js
@@ -5,10 +5,10 @@ module.exports = function(keycloak, logoutUrl) {
       return next();
     }
 
-    if ( request.auth.grant ) {
+    if ( request.kauth.grant ) {
       keycloak.deauthenticated( request );
-      request.auth.grant.unstore(request, response);
-      delete request.auth.grant;
+      request.kauth.grant.unstore(request, response);
+      delete request.kauth.grant;
     }
 
     var host = request.hostname;

--- a/connect/middleware/post-auth.js
+++ b/connect/middleware/post-auth.js
@@ -23,7 +23,7 @@ module.exports = function(keycloak) {
 
         var cleanUrl = URL.format( urlParts );
         
-        request.auth.grant = grant;
+        request.kauth.grant = grant;
         try {
           keycloak.authenticated( request );
         } catch (err) {

--- a/connect/middleware/protect.js
+++ b/connect/middleware/protect.js
@@ -35,8 +35,8 @@ module.exports = function(keycloak, spec) {
   }
 
   return function(request, response, next) {
-    if ( request.auth && request.auth.grant ) {
-      if ( ! guard || guard( request.auth.grant.access_token, request, response ) ) {
+    if ( request.kauth && request.kauth.grant ) {
+      if ( ! guard || guard( request.kauth.grant.access_token, request, response ) ) {
         return next();
       }
 

--- a/connect/middleware/setup.js
+++ b/connect/middleware/setup.js
@@ -1,5 +1,5 @@
 
 module.exports = function(request, response, next) {
-  request.auth = {};
+  request.kauth = {};
   next();
 };


### PR DESCRIPTION
The connect-keycloak module attachs a property '.auth' to Express's 'Request' object. It works on Express4 but not so on Express3 because Express3 has defned Getter:

req.__defineGetter__('auth', function(){
  deprecate('req.auth: Use basic-auth npm module instead');

  // credentials
  var creds = auth(this);
  if (!creds) return;

  return { username: creds.name, password: creds.pass };
});

Renaming the property to a different name, '.kauth' for example made it usable on Express3.

