### PR TITLE
Fix hardcoded protocol and port redirect

### DIFF
--- a/auth-utils/grant-manager.js
+++ b/auth-utils/grant-manager.js
@@ -127,7 +127,6 @@ GrantManager.prototype.obtainFromCode = function(request, code, sessionId, sessi
   var deferred = Q.defer();
   var self = this;
 
-  console.log( "request.session", request.session );
   var redirectUri = encodeURIComponent( request.session.auth_redirect_uri );
 
   var params = 'code=' + code + '&application_session_state=' + sessionId + '&redirect_uri=' + redirectUri + '&application_session_host=' + sessionHost;

--- a/connect/middleware/logout.js
+++ b/connect/middleware/logout.js
@@ -12,9 +12,10 @@ module.exports = function(keycloak, logoutUrl) {
     }
 
     var host = request.hostname;
-    var port = request.app.settings.port || 3000;
+    var headerHost = request.headers.host.split(':');
+    var port = headerHost[1] || '';
 
-    var redirectUrl = 'http://' + host + ( port == 80 ? '' : ':' + port ) + '/';
+    var redirectUrl = request.protocol + '://' + host + ( port == '' ? '' : ':' + port ) + '/';
 
     var keycloakLogoutUrl = keycloak.logoutUrl(redirectUrl);
 

--- a/connect/middleware/protect.js
+++ b/connect/middleware/protect.js
@@ -2,9 +2,11 @@ var UUID = require('./../uuid' );
 
 function forceLogin(keycloak, request, response) {
   var host = request.hostname;
-  var port = request.app.settings.port || 3000;
+  var headerHost = request.headers.host.split(':');
+  var port = headerHost[1] || '';
+  var protocol = request.protocol;
 
-  var redirectUrl = 'http://' + host + ( port == 80 ? '' : ':' + port ) + request.url + '?auth_callback=1';
+  var redirectUrl = protocol + '://' + host + ( port == '' ? '' : ':' + port ) + request.url + '?auth_callback=1';
 
   request.session.auth_redirect_uri = redirectUrl;
 


### PR DESCRIPTION
In the connect/middleware/logout.js and connect/middleware/protect.js the protocol is hardcoded. I changed this to get from request and obtain the port from header.