### PR TITLE
FIX: deserialize stored token

### DIFF
--- a/connect/index.js
+++ b/connect/index.js
@@ -233,6 +233,10 @@ Keycloak.prototype.getGrant = function(request, response) {
     }
   }
 
+  if (rawData) {
+    rawData = JSON.parse(rawData);
+  }
+
   if ( rawData && ! rawData.error ) {
     var grant = this.grantManager.createGrant( JSON.stringify(rawData) );
     var self = this;


### PR DESCRIPTION
This is a fix for a bug in master. In my use case at least it's causing a redirect loop because the grant-attacher fails to attach the grant even when the user is authenticated.

As far as I can tell rawData is always the value from grant.__raw, set in createGrant and is always JSON (or undefined). It needs to be deserialized to be able to check rawData.error.